### PR TITLE
add order option to belongs_to

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -70,6 +70,10 @@ specify, including:
 Each of the `Field` types take a different set of options,
 which are specified through the `.with_options` class method:
 
+**Field::BelongsTo**
+
+`:order` - order of the dropdown menu, can be ordered by more than one column `"name, email DESC"`
+
 **Field::HasMany**
 
 `:limit` - Set the number of resources to display in the show view. Default is

--- a/lib/administrate/field/belongs_to.rb
+++ b/lib/administrate/field/belongs_to.rb
@@ -24,7 +24,8 @@ module Administrate
       private
 
       def candidate_resources
-        associated_class.all
+        order = options.delete(:order)
+        order ? associated_class.order(order) : associated_class.all
       end
 
       def display_candidate_resource(resource)

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -66,4 +66,19 @@ describe Administrate::Field::BelongsTo do
       end
     end
   end
+
+  describe "#resources" do
+    context "with `order` option" do
+      it "returns the resources in correct order" do
+        5.times{ FactoryGirl.create(:customer) }
+        options = { order: "name" }
+        association = Administrate::Field::BelongsTo.with_options(options)
+        field = association.new(:customers, [], :view)
+
+        correct_order = Customer.all.order("name").map(&:id)
+
+        expect(field.associated_resource_options.drop(1).map {|row| row[1]}).to eq correct_order
+      end
+    end
+  end
 end


### PR DESCRIPTION
make it possible to order the drop-down menu of a belongs_to field.

- add optional option `:order`
- create tests for `:order` option
- update the doc